### PR TITLE
Avoid std::memcpy with a null pointer when unpacking an empty FixStr

### DIFF
--- a/include/msgpack/v2/create_object_visitor.hpp
+++ b/include/msgpack/v2/create_object_visitor.hpp
@@ -115,7 +115,9 @@ public:
         }
         else {
             char* tmp = static_cast<char*>(zone().allocate_align(size, MSGPACK_ZONE_ALIGNOF(char)));
-            std::memcpy(tmp, v, size);
+            // An empty FixStr ("\xa0") reaches here with a null source pointer and zero size;
+            // std::memcpy declares both pointers as nonnull, so guard the copy to avoid undefined behavior.
+            if (size) std::memcpy(tmp, v, size);
             obj->via.str.ptr = tmp;
         }
         obj->via.str.size = size;
@@ -131,7 +133,8 @@ public:
         }
         else {
             char* tmp = static_cast<char*>(zone().allocate_align(size, MSGPACK_ZONE_ALIGNOF(char)));
-            std::memcpy(tmp, v, size);
+            // Guard against a null source pointer with zero size (std::memcpy declares both pointers as nonnull).
+            if (size) std::memcpy(tmp, v, size);
             obj->via.bin.ptr = tmp;
         }
         obj->via.bin.size = size;
@@ -147,7 +150,8 @@ public:
         }
         else {
             char* tmp = static_cast<char*>(zone().allocate_align(size, MSGPACK_ZONE_ALIGNOF(char)));
-            std::memcpy(tmp, v, size);
+            // Guard against a null source pointer with zero size (std::memcpy declares both pointers as nonnull).
+            if (size) std::memcpy(tmp, v, size);
             obj->via.ext.ptr = tmp;
         }
         obj->via.ext.size = static_cast<uint32_t>(size - 1);


### PR DESCRIPTION
Avoid undefined behavior when unpacking an empty MsgPack FixStr.

An empty string is encoded as an empty FixStr (the single byte `\xa0`). While unpacking it, `create_object_visitor::visit_str` allocates a zero-length buffer and calls `std::memcpy(dst, v, 0)` where the source pointer `v` is null — the parser never assigns it for FixStr, which carries no trailing bytes. `std::memcpy` declares both pointers as nonnull, so this is undefined behavior reported by UndefinedBehaviorSanitizer:

```
create_object_visitor.hpp:118:30: runtime error: null pointer passed as argument 2, which is declared to never be null
```

Guard the copy with a zero-size check in `visit_str`, `visit_bin` and `visit_ext`. The behavior is unchanged for non-empty values.

Used by https://github.com/ClickHouse/ClickHouse/pull/108246
